### PR TITLE
Sorting NCC order slips by Den

### DIFF
--- a/packman/campaigns/views.py
+++ b/packman/campaigns/views.py
@@ -451,12 +451,17 @@ class OrderSlipView(PermissionRequiredMixin, TemplateView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         campaign = Campaign.objects.latest()
-        context["order_list"] = (
+        order_list = (
             Order.objects.filter(campaign=campaign, item__isnull=False)
             .distinct()
             .calculate_total()
             .select_related("seller", "customer")
             .prefetch_related("items", "items__product")
-            .order_by("seller")
+            .order_by("seller__current_den")
         )
+
+        # sort the order list by seller current_den
+        context["order_list"] = list(order_list.all())
+        context["order_list"].sort(key=lambda x: x.seller.current_den.number)
+
         return context


### PR DESCRIPTION
To ease packing slip distribution on packing night, sorting the printout by den instead of surname.

(If this can be done more easily in the QueryFilter please LMK)