### PR TITLE
Update views.py - NCC report was failing while any sellers are without a current den

### DIFF
--- a/packman/campaigns/views.py
+++ b/packman/campaigns/views.py
@@ -466,6 +466,6 @@ class OrderSlipView(PermissionRequiredMixin, TemplateView):
 
         # sort the order list by seller current_den
         context["order_list"] = list(order_list.all())
-        context["order_list"].sort(key=lambda x: x.seller.current_den.number)
+        context["order_list"].sort(key=lambda x: x.seller.current_den.number if x.seller.current_den else 666)
 
         return context


### PR DESCRIPTION
fix: avoid report failure when a seller doesn't have a current_den, sort those to end.
There may be other problems with "between season" reports when sellers may lack current_den or other info, but just seeking to have NCC folks unblocked with these reports. With this change, the Order Slip report does work, with (presumably) graduated cubs like Tuvia Antolin and a bunch of others showing with "None" den.

[pid: 14802|app: 0|req: 47642/405391] 127.0.0.1 () {48 vars in 744 bytes} [Mon Aug 18 19:30:15 2025] GET /events/aggregator/icalendar.ics => generated 6388 bytes in 59 msecs (HTTP/1.1 404) 8 headers in 288 bytes (1 switches on core 0)
Internal Server Error: /ncc/reports/order_slips/
Traceback (most recent call last):
  File "/home/pack144/.pyenv/versions/packman/lib/python3.10/site-packages/django/core/handlers/exception.py", line 47, in inner
    response = get_response(request)
  File "/home/pack144/.pyenv/versions/packman/lib/python3.10/site-packages/django/core/handlers/base.py", line 181, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "/home/pack144/.pyenv/versions/packman/lib/python3.10/site-packages/sentry_sdk/integrations/django/views.py", line 84, in sentry_wrapped_callback
    return callback(request, *args, **kwargs)
  File "/home/pack144/.pyenv/versions/packman/lib/python3.10/site-packages/django/views/generic/base.py", line 70, in view
    return self.dispatch(request, *args, **kwargs)
  File "/home/pack144/.pyenv/versions/packman/lib/python3.10/site-packages/django/contrib/auth/mixins.py", line 104, in dispatch
    return super().dispatch(request, *args, **kwargs)
  File "/home/pack144/.pyenv/versions/packman/lib/python3.10/site-packages/django/views/generic/base.py", line 98, in dispatch
    return handler(request, *args, **kwargs)
  File "/home/pack144/.pyenv/versions/packman/lib/python3.10/site-packages/django/views/generic/base.py", line 159, in get
    context = self.get_context_data(**kwargs)
  File "/home/pack144/apps/django/packman/packman/campaigns/views.py", line 465, in get_context_data
    context["order_list"].sort(key=lambda x: x.seller.current_den.number)
  File "/home/pack144/apps/django/packman/packman/campaigns/views.py", line 465, in <lambda>
    context["order_list"].sort(key=lambda x: x.seller.current_den.number)
AttributeError: 'NoneType' object has no attribute 'number'

## Summary by Sourcery

Fix NCC report failure by defaulting missing current_den in sort key and moving sellers without a den to the end

Bug Fixes:
- Prevent AttributeError in NCC Order Slip report by handling missing seller.current_den during sorting

Enhancements:
- Sort sellers without a current den to the end of the order list