### PR TITLE
Fix campaign report admin action

### DIFF
--- a/packman/campaigns/admin.py
+++ b/packman/campaigns/admin.py
@@ -211,10 +211,19 @@ class OrderAdmin(admin.ModelAdmin):
 
     @admin.display(description=_("Generate Campaign Report"))
     def generate_campaign_report(self, request, queryset):
-        campaign = Campaign.objects.current()
+        # Determine campaign from the selected orders
+        campaign_ids = set(queryset.values_list('campaign', flat=True))
+        if len(campaign_ids) != 1:
+            self.message_user(
+                request,
+                _(f"Please select orders from a single campaign (found {len(campaign_ids)} campaigns: {campaign_ids})"),
+                messages.ERROR,
+            )
+            return
+        campaign = Campaign.objects.get(pk=list(campaign_ids)[0])
+
         report_date = timezone.now()
-        orders = Order.objects.filter(campaign=campaign)
-        report_name = f"Campaign Report ({report_date.month}-{report_date.day}-{report_date.year}).csv"
+        report_name = f"Campaign Report - {campaign.year} ({report_date.month}-{report_date.day}-{report_date.year}).csv"
 
         field_names = [
             "Cub",
@@ -238,9 +247,12 @@ class OrderAdmin(admin.ModelAdmin):
         writer = csv.writer(response)
         writer.writerow(field_names)
         for cub in cubs:
-            cub_orders = orders.filter(seller__den_memberships=cub)
+            cub_orders = queryset.filter(seller__den_memberships=cub)
             total = cub_orders.totaled()["totaled"]
-            quota = cub.den.quotas.current().target
+            try:
+                quota = cub.den.quotas.filter(campaign=campaign).first().target
+            except (Quota.DoesNotExist, AttributeError):
+                quota = 0  # Default to 0 if no quota is set for this den
 
             # calculate points earned
             if total < quota:

--- a/packman/campaigns/admin.py
+++ b/packman/campaigns/admin.py
@@ -212,18 +212,20 @@ class OrderAdmin(admin.ModelAdmin):
     @admin.display(description=_("Generate Campaign Report"))
     def generate_campaign_report(self, request, queryset):
         # Determine campaign from the selected orders
-        campaign_ids = set(queryset.values_list('campaign', flat=True))
+        campaign_ids = set(queryset.values_list("campaign", flat=True))
         if len(campaign_ids) != 1:
             self.message_user(
                 request,
-                _(f"Please select orders from a single campaign (found {len(campaign_ids)} campaigns: {campaign_ids})"),
+                _(f"Please select orders from a single campaign (found {len(campaign_ids)} campaigns: {campaign_ids})"),  # nosec B608
                 messages.ERROR,
             )
             return
         campaign = Campaign.objects.get(pk=list(campaign_ids)[0])
 
         report_date = timezone.now()
-        report_name = f"Campaign Report - {campaign.year} ({report_date.month}-{report_date.day}-{report_date.year}).csv"
+        report_name = (
+            f"Campaign Report - {campaign.year} ({report_date.month}-{report_date.day}-{report_date.year}).csv"
+        )
 
         field_names = [
             "Cub",

--- a/packman/campaigns/admin.py
+++ b/packman/campaigns/admin.py
@@ -216,7 +216,10 @@ class OrderAdmin(admin.ModelAdmin):
         if len(campaign_ids) != 1:
             self.message_user(
                 request,
-                _(f"Please select orders from a single campaign (found {len(campaign_ids)} campaigns: {campaign_ids})"),  # nosec B608
+                _(
+                    "Please select orders from a single campaign"  # nosec B608
+                    f" (found {len(campaign_ids)} campaigns: {campaign_ids})"
+                ),
                 messages.ERROR,
             )
             return
@@ -251,10 +254,8 @@ class OrderAdmin(admin.ModelAdmin):
         for cub in cubs:
             cub_orders = queryset.filter(seller__den_memberships=cub)
             total = cub_orders.totaled()["totaled"]
-            try:
-                quota = cub.den.quotas.filter(campaign=campaign).first().target
-            except (Quota.DoesNotExist, AttributeError):
-                quota = 0  # Default to 0 if no quota is set for this den
+            quota_obj = cub.den.quotas.filter(campaign=campaign).first()
+            quota = quota_obj.target if quota_obj is not None else 0
 
             # calculate points earned
             if total < quota:


### PR DESCRIPTION
## Summary
These are slightly cleaned up changes that somebody hacked live on prod, probably from a couple years ago or more.
- `generate_campaign_report` now derives the campaign from the selected orders rather than always using the current campaign, so it works correctly for historical campaigns
- Validates all selected orders belong to a single campaign and shows an error if not
- Quota lookup changed from `.current()` to `.filter(campaign=campaign).first()` with error handling for missing quotas
- Report filename now includes the campaign year

## Summary by Sourcery

Fix the admin campaign report action to derive the campaign from the selected orders, handle missing or inconsistent campaign data, and improve quota lookup and report naming.

Bug Fixes:
- Ensure the campaign report uses the campaign associated with the selected orders instead of always using the current campaign.
- Validate that all selected orders belong to a single campaign and show an error when multiple campaigns are selected.
- Handle cases where a den has no quota for the campaign by defaulting the quota to zero instead of raising an error.

Enhancements:
- Include the campaign year in the generated campaign report filename for clearer identification.