### PR TITLE
Fix weekly campaign report and quota display

### DIFF
--- a/packman/campaigns/reports.py
+++ b/packman/campaigns/reports.py
@@ -115,7 +115,6 @@ def generate_weekly_report(request):
     report_name = f"Campaign Weekly Report ({begin_date.month}-{begin_date.day}-{begin_date.year} to {end_date.month}-{end_date.day}-{end_date.year}).csv"  # noqa: E501
     field_names = ["Cub", "Den", "Order Count", "Total Sales"]
 
-
     orders = Order.objects.filter(date_added__gte=begin_date, date_added__lte=end_date)
     members = Membership.objects.prefetch_related("scout", "den").filter(year_assigned=PackYear.objects.current())
 

--- a/packman/campaigns/reports.py
+++ b/packman/campaigns/reports.py
@@ -4,6 +4,7 @@ import decimal
 from django.http import HttpResponse, StreamingHttpResponse
 from django.utils import dateparse, timezone
 
+from packman.calendars.models import PackYear
 from packman.campaigns.models import Campaign, Order, PrizePoint, PrizeSelection
 from packman.dens.models import Membership
 
@@ -114,10 +115,9 @@ def generate_weekly_report(request):
     report_name = f"Campaign Weekly Report ({begin_date.month}-{begin_date.day}-{begin_date.year} to {end_date.month}-{end_date.day}-{end_date.year}).csv"  # noqa: E501
     field_names = ["Cub", "Den", "Order Count", "Total Sales"]
 
+
     orders = Order.objects.filter(date_added__gte=begin_date, date_added__lte=end_date)
-    members = (
-        Membership.objects.prefetch_related("scout", "den").filter(scout__orders__in=orders).distinct().order_by("den")
-    )
+    members = Membership.objects.prefetch_related("scout", "den").filter(year_assigned=PackYear.objects.current())
 
     response = HttpResponse(content_type="text/csv")
     response["Content-Disposition"] = f"attachment; filename={report_name}"
@@ -126,6 +126,6 @@ def generate_weekly_report(request):
 
     for cub in members:
         cub_orders = orders.filter(seller__den_memberships=cub)
-        writer.writerow([cub.scout, cub.den, cub_orders.count(), cub_orders.totaled()["totaled"]])
+        writer.writerow([cub.scout, cub.scout.get_current_den(), cub_orders.count(), cub_orders.totaled()["totaled"]])
 
     return response

--- a/packman/campaigns/templates/campaigns/snippets/quota_progress.html
+++ b/packman/campaigns/templates/campaigns/snippets/quota_progress.html
@@ -37,7 +37,7 @@
       {% widthratio 1500 1500 22 as silver_progress %}
       {% widthratio total 2000 22 as gold_progress %}
       <div class="text-end">
-        <strong>golden nugget contender</strong>
+        <strong>Golden Peanut Contender</strong>
       </div>
     {% endif %}
     <div class="progress-stacked">


### PR DESCRIPTION
## Summary
These are slightly cleaned up changes that somebody hacked live on prod, probably from a couple years ago or more.
- Weekly report now lists all current-year members, not just those with orders — makes it useful for tracking who hasn't ordered yet
- Uses \`get_current_den()\` for the den column, matching how dens are displayed elsewhere
- Capitalizes "Golden Peanut Contender" correctly in quota progress display

## Summary by Sourcery

Update the weekly campaign report to include all current-year members and align den display and quota labels with existing conventions.

New Features:
- Generate the weekly campaign report for all members in the current pack year rather than only those with orders in the selected period.

Bug Fixes:
- Fix den display in the weekly campaign report to use each scout's current den for consistency across the app.
- Correct the capitalization and wording of the Golden Peanut Contender label in the quota progress display.