### PR TITLE
Add system information page to admin

### DIFF
--- a/packman/core/views.py
+++ b/packman/core/views.py
@@ -1,0 +1,49 @@
+import platform
+import sys
+from importlib.metadata import distributions
+
+import django
+from django.contrib import admin
+from django.db import connection
+from django.shortcuts import render
+
+
+def system_info(request):
+    # OS
+    try:
+        os_release = platform.freedesktop_os_release()
+        os_name = os_release.get("PRETTY_NAME", platform.platform())
+    except (AttributeError, OSError):
+        os_name = platform.platform()
+
+    # Database
+    db_vendor = connection.vendor
+    with connection.cursor() as cursor:
+        if db_vendor == "postgresql":
+            cursor.execute("SELECT version()")
+            db_version = cursor.fetchone()[0]
+        elif db_vendor == "sqlite":
+            cursor.execute("SELECT sqlite_version()")
+            db_version = f"SQLite {cursor.fetchone()[0]}"
+        elif db_vendor == "mysql":
+            cursor.execute("SELECT VERSION()")
+            db_version = f"MySQL {cursor.fetchone()[0]}"
+        else:
+            db_version = db_vendor
+
+    packages = sorted(
+        ((d.metadata["Name"], d.metadata["Version"]) for d in distributions()),
+        key=lambda x: x[0].lower(),
+    )
+
+    context = {
+        **admin.site.each_context(request),
+        "title": "System Information",
+        "python_version": sys.version,
+        "django_version": django.__version__,
+        "os_name": os_name,
+        "db_vendor": db_vendor,
+        "db_version": db_version,
+        "packages": packages,
+    }
+    return render(request, "admin/system_info.html", context)

--- a/packman/templates/admin/index.html
+++ b/packman/templates/admin/index.html
@@ -1,0 +1,19 @@
+{% extends "admin/index.html" %}
+{% load i18n %}
+
+{% block content %}
+<div id="content-main">
+  <div class="app-packman module">
+    <table>
+      <caption>{% trans "System" %}</caption>
+      <tbody>
+        <tr>
+          <th scope="row"><a href="{% url 'admin_system_info' %}">{% trans "System Information" %}</a></th>
+          <td></td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+  {% include "admin/app_list.html" with app_list=app_list show_changelinks=True %}
+</div>
+{% endblock %}

--- a/packman/templates/admin/index.html
+++ b/packman/templates/admin/index.html
@@ -1,9 +1,19 @@
-{% extends "admin/index.html" %}
-{% load i18n %}
+{% extends "admin/base_site.html" %}
+{% load i18n static log %}
+
+{% block extrastyle %}{{ block.super }}<link rel="stylesheet" href="{% static "admin/css/dashboard.css" %}">{% endblock %}
+
+{% block coltype %}colMS{% endblock %}
+
+{% block bodyclass %}{{ block.super }} dashboard{% endblock %}
+
+{% block nav-breadcrumbs %}{% endblock %}
+
+{% block nav-sidebar %}{% endblock %}
 
 {% block content %}
 <div id="content-main">
-  <div class="app-packman module">
+  <div class="module">
     <table>
       <caption>{% trans "System" %}</caption>
       <tbody>
@@ -15,5 +25,37 @@
     </table>
   </div>
   {% include "admin/app_list.html" with app_list=app_list show_changelinks=True %}
+</div>
+{% endblock %}
+
+{% block sidebar %}
+<div id="content-related">
+  <div class="module" id="recent-actions-module">
+    <h2>{% trans "Recent actions" %}</h2>
+    <h3>{% trans "My actions" %}</h3>
+    {% get_admin_log 10 as admin_log for_user user %}
+    {% if not admin_log %}
+    <p>{% trans "None available" %}</p>
+    {% else %}
+    <ul class="actionlist">
+      {% for entry in admin_log %}
+      <li class="{% if entry.is_addition %}addlink{% endif %}{% if entry.is_change %}changelink{% endif %}{% if entry.is_deletion %}deletelink{% endif %}">
+        <span class="visually-hidden">{% if entry.is_addition %}{% trans "Added:" %}{% elif entry.is_change %}{% trans "Changed:" %}{% elif entry.is_deletion %}{% trans "Deleted:" %}{% endif %}</span>
+        {% if entry.is_deletion or not entry.get_admin_url %}
+          {{ entry.object_repr }}
+        {% else %}
+          <a href="{{ entry.get_admin_url }}">{{ entry.object_repr }}</a>
+        {% endif %}
+        <br>
+        {% if entry.content_type %}
+          <span class="mini quiet">{% filter capfirst %}{{ entry.content_type.name }}{% endfilter %}</span>
+        {% else %}
+          <span class="mini quiet">{% trans "Unknown content" %}</span>
+        {% endif %}
+      </li>
+      {% endfor %}
+    </ul>
+    {% endif %}
+  </div>
 </div>
 {% endblock %}

--- a/packman/templates/admin/system_info.html
+++ b/packman/templates/admin/system_info.html
@@ -1,0 +1,55 @@
+{% extends "admin/base_site.html" %}
+{% load i18n %}
+
+{% block breadcrumbs %}
+<div class="breadcrumbs">
+  <a href="{% url 'admin:index' %}">{% trans "Home" %}</a>
+  &rsaquo; {% trans "System Information" %}
+</div>
+{% endblock %}
+
+{% block content %}
+<div id="content-main">
+
+  <h2>{% trans "Environment" %}</h2>
+  <table>
+    <tbody>
+      <tr>
+        <th scope="row">{% trans "Python" %}</th>
+        <td><code>{{ python_version }}</code></td>
+      </tr>
+      <tr>
+        <th scope="row">{% trans "Django" %}</th>
+        <td><code>{{ django_version }}</code></td>
+      </tr>
+      <tr>
+        <th scope="row">{% trans "Operating System" %}</th>
+        <td><code>{{ os_name }}</code></td>
+      </tr>
+      <tr>
+        <th scope="row">{% trans "Database" %}</th>
+        <td><code>{{ db_version }}</code></td>
+      </tr>
+    </tbody>
+  </table>
+
+  <h2>{% trans "Installed Packages" %}</h2>
+  <table>
+    <thead>
+      <tr>
+        <th scope="col">{% trans "Package" %}</th>
+        <th scope="col">{% trans "Version" %}</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for name, version in packages %}
+      <tr>
+        <td>{{ name }}</td>
+        <td><code>{{ version }}</code></td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+
+</div>
+{% endblock %}

--- a/packman/urls.py
+++ b/packman/urls.py
@@ -18,13 +18,17 @@ Including another URLconf
 from django.conf import settings
 from django.conf.urls.static import static
 from django.contrib import admin
+from django.contrib.admin.views.decorators import staff_member_required
 from django.urls import include, path
 from django.views import defaults as default_views
 from django.views.generic import RedirectView
 
+from packman.core.views import system_info
+
 urlpatterns = [
     # Django admin
     path("administration/doc/", include("django.contrib.admindocs.urls")),
+    path("administration/system-info/", staff_member_required(system_info), name="admin_system_info"),
     path("administration/", admin.site.urls),
     # Account management
     path("members/", include("django.contrib.auth.urls")),


### PR DESCRIPTION
## Summary

- Adds `/administration/system-info/` showing Python version, Django version, OS distro/version, database type and full version string, and a sorted table of all installed packages
- Page is staff-only (via `staff_member_required`)
- Linked from a "System" section at the top of the admin index page (`admin/index.html` override)

## Test plan

- [ ] Visit `/administration/system-info/` — verify environment and package table render correctly
- [ ] Confirm "System Information" link appears at the top of `/administration/` index
- [ ] Confirm Recent Actions sidebar is unaffected on the index page
- [ ] Confirm non-staff users are redirected to login

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add a staff-only Django admin system information view and link it from the admin index page.

New Features:
- Expose a staff-only `/administration/system-info/` endpoint showing environment details and installed packages.
- Add an admin template for displaying Python, Django, OS, database version, and a sorted list of installed packages.
- Surface a "System Information" entry in a new System section at the top of the admin index page.

Enhancements:
- Integrate system information view with Django admin context to match existing admin look and feel.