### PR TITLE
Replace 'f'/'t' with 0/1 in pg_to_sqlite util.

### DIFF
--- a/util/pg_to_sqlite.py
+++ b/util/pg_to_sqlite.py
@@ -413,8 +413,14 @@ def pg_value_to_sqlite(value: str) -> str:
     value = value.replace(r"\n", "\n")
     value = value.replace(r"\r", "\r")
     value = value.replace(r"\t", "\t")
+    # Replace boolean 't' with 1
+    if value == "t":
+        value = 1
+    # Replace boolean 'f' with 0
+    elif value == "f":
+        value = 0
     # Normalise UUIDs: Django's SQLite backend expects 32-char hex without hyphens
-    if _UUID_RE.match(value):
+    elif _UUID_RE.match(value):
         value = value.replace("-", "")
     return value
 

--- a/util/pg_to_sqlite.py
+++ b/util/pg_to_sqlite.py
@@ -415,10 +415,10 @@ def pg_value_to_sqlite(value: str) -> str:
     value = value.replace(r"\t", "\t")
     # Replace boolean 't' with '1'
     if value == "t":
-        value = '1'
+        value = "1"
     # Replace boolean 'f' with '0'
     elif value == "f":
-        value = '0'
+        value = "0"
     # Normalise UUIDs: Django's SQLite backend expects 32-char hex without hyphens
     elif _UUID_RE.match(value):
         value = value.replace("-", "")

--- a/util/pg_to_sqlite.py
+++ b/util/pg_to_sqlite.py
@@ -413,12 +413,12 @@ def pg_value_to_sqlite(value: str) -> str:
     value = value.replace(r"\n", "\n")
     value = value.replace(r"\r", "\r")
     value = value.replace(r"\t", "\t")
-    # Replace boolean 't' with 1
+    # Replace boolean 't' with '1'
     if value == "t":
-        value = 1
-    # Replace boolean 'f' with 0
+        value = '1'
+    # Replace boolean 'f' with '0'
     elif value == "f":
-        value = 0
+        value = '0'
     # Normalise UUIDs: Django's SQLite backend expects 32-char hex without hyphens
     elif _UUID_RE.match(value):
         value = value.replace("-", "")


### PR DESCRIPTION
SQLite doesn't have booleans, instead it uses integers with 0/1.  This breaks viewing any admin pages that have booleans (such as the committees page).

This is a little quick and dirty as if we have any text values with nothing but 't' or 'f' it will also replace those, but seems to work fine with our current dump.

## Summary by Sourcery

Bug Fixes:
- Convert 't'/'f' string values to '1'/'0' during PostgreSQL-to-SQLite value translation so boolean fields work correctly in SQLite-backed admin pages.