### PR TITLE
Add admin action to roll Cubs into current den after Pack Year rollover

### DIFF
--- a/packman/membership/admin.py
+++ b/packman/membership/admin.py
@@ -20,6 +20,7 @@ from packman.address_book.forms import AddressForm, PhoneNumberForm
 from packman.address_book.models import Address, PhoneNumber
 from packman.calendars.models import PackYear
 from packman.committees.models import CommitteeMember
+from packman.dens.models import Den
 from packman.dens.models import Membership as DenMembership
 from packman.dens.models import Rank
 
@@ -142,6 +143,7 @@ class ScoutAdmin(admin.ModelAdmin):
         "make_inactive",
         "make_graduated",
         "continue_in_same_den_one_more_year",
+        "continue_in_same_den_from_last_year",
         "export_roster_csv",
         "export_for_grandprix",
     ]
@@ -314,18 +316,21 @@ class ScoutAdmin(admin.ModelAdmin):
             messages.SUCCESS,
         )
 
-    @admin.action(description=_("Assign selected Cubs to the same den for the next Pack Year"))
-    def continue_in_same_den_one_more_year(self, request, queryset):
-        next_year, created = PackYear.objects.get_or_create(year=PackYear.get_current().pk + 1)
+    def _continue_in_same_den(self, request, queryset, source_year, target_year):
+        """Assign each Cub in the queryset to the den they held during source_year, for target_year."""
         n = queryset.count()
         if n:
             for obj in queryset:
-                if obj.current_den:
-                    m, c = DenMembership.objects.get_or_create(den=obj.current_den, scout=obj, year_assigned=next_year)
+                try:
+                    den = Den.objects.get(scouts__scout=obj, scouts__year_assigned=source_year)
+                except Den.DoesNotExist:
+                    den = None
+                if den:
+                    m, c = DenMembership.objects.get_or_create(den=den, scout=obj, year_assigned=target_year)
                     if not c:
                         self.message_user(
                             request,
-                            _(f"{obj} is already assigned to Den {obj.current_den} for the {next_year} Pack Year."),
+                            _(f"{obj} is already assigned to Den {den} for the {target_year} Pack Year."),
                             messages.WARNING,
                         )
                         n -= 1
@@ -333,17 +338,37 @@ class ScoutAdmin(admin.ModelAdmin):
                     n -= 1
                     self.message_user(
                         request,
-                        _(f"{obj} is not currently assigned to a den."),
+                        _(f"{obj} was not assigned to a den for the {source_year} Pack Year."),
                         messages.WARNING,
                     )
         self.message_user(
             request,
             ngettext(
-                f"Successfully rolled {n} Cub into the {next_year} Pack Year.",
-                f"Successfully rolled {n} Cubs into the {next_year} Pack Year.",
+                f"Successfully rolled {n} Cub into the {target_year} Pack Year.",
+                f"Successfully rolled {n} Cubs into the {target_year} Pack Year.",
                 n,
             ),
             messages.SUCCESS,
+        )
+
+    @admin.action(description=_("Assign selected Cubs to the same den for the next Pack Year"))
+    def continue_in_same_den_one_more_year(self, request, queryset):
+        current_year = PackYear.objects.current()
+        next_year, created = PackYear.objects.get_or_create(year=current_year.pk + 1)
+        self._continue_in_same_den(request, queryset, source_year=current_year, target_year=next_year)
+
+    @admin.action(description=_("Assign selected Cubs to the same den from last Pack Year"))
+    def continue_in_same_den_from_last_year(self, request, queryset):
+        """
+        For use once the current Pack Year has already rolled over and Cubs
+        weren't pre-assigned to a den for it ahead of time.
+        """
+        previous_year = PackYear.objects.previous()
+        if not previous_year:
+            self.message_user(request, _("There is no previous Pack Year on record."), messages.ERROR)
+            return
+        self._continue_in_same_den(
+            request, queryset, source_year=previous_year, target_year=PackYear.objects.current()
         )
 
     @admin.action(description=_("Export selected Cubs to CSV (roster)"))

--- a/packman/membership/admin.py
+++ b/packman/membership/admin.py
@@ -351,13 +351,13 @@ class ScoutAdmin(admin.ModelAdmin):
             messages.SUCCESS,
         )
 
-    @admin.action(description=_("Assign selected Cubs to the same den for the next Pack Year"))
+    @admin.action(description=_("Before July 1 (pre-rollover): assign selected Cubs to next Pack Year's den"))
     def continue_in_same_den_one_more_year(self, request, queryset):
         current_year = PackYear.objects.current()
         next_year, created = PackYear.objects.get_or_create(year=current_year.pk + 1)
         self._continue_in_same_den(request, queryset, source_year=current_year, target_year=next_year)
 
-    @admin.action(description=_("Assign selected Cubs to the same den from last Pack Year"))
+    @admin.action(description=_("After June 30 (post-rollover): assign selected Cubs to same den as last Pack Year"))
     def continue_in_same_den_from_last_year(self, request, queryset):
         """
         For use once the current Pack Year has already rolled over and Cubs

--- a/util/seed_dev_data.py
+++ b/util/seed_dev_data.py
@@ -1,0 +1,44 @@
+"""
+Populate the local database with fake data for development, using the
+project's factory_boy factories (packman/*/factories.py).
+
+Usage:
+    uv run python manage.py shell < util/seed_dev_data.py
+"""
+
+import random
+
+from packman.calendars.factories import CategoryFactory, CurrentPackYearFactory, EventFactory
+from packman.dens.factories import CurrentMembershipFactory, DenFactory
+from packman.membership.factories import AdultFactory, FamilyFactory, ScoutFactory
+from packman.membership.models import Scout
+
+random.seed(42)
+
+print("Seeding dens...")
+dens = [DenFactory(number=n) for n in range(1, 6)]
+
+print("Seeding families, adults, and scouts...")
+families = []
+for _ in range(20):
+    family = FamilyFactory()
+    for _ in range(random.randint(1, 2)):
+        AdultFactory(family=family)
+    for _ in range(random.randint(1, 2)):
+        scout = ScoutFactory(family=family, status=Scout.ACTIVE)
+        CurrentMembershipFactory(scout=scout, den=random.choice(dens))
+    if random.random() < 0.25:
+        ScoutFactory(family=family, status=Scout.INACTIVE)
+    families.append(family)
+
+print("Seeding calendar categories and events...")
+categories = [CategoryFactory() for _ in range(4)]
+for category in categories:
+    for _ in range(5):
+        EventFactory(category=category, future=random.choice([True, False]))
+
+CurrentPackYearFactory()
+
+print("Done.")
+print(f"Families: {len(families)}")
+print(f"Dens: {len(dens)}")

--- a/util/seed_dev_data.py
+++ b/util/seed_dev_data.py
@@ -22,12 +22,12 @@ print("Seeding families, adults, and scouts...")
 families = []
 for _ in range(20):
     family = FamilyFactory()
-    for _ in range(random.randint(1, 2)):
+    for _ in range(random.randint(1, 2)):  # nosec B311
         AdultFactory(family=family)
-    for _ in range(random.randint(1, 2)):
+    for _ in range(random.randint(1, 2)):  # nosec B311
         scout = ScoutFactory(family=family, status=Scout.ACTIVE)
-        CurrentMembershipFactory(scout=scout, den=random.choice(dens))
-    if random.random() < 0.25:
+        CurrentMembershipFactory(scout=scout, den=random.choice(dens))  # nosec B311
+    if random.random() < 0.25:  # nosec B311
         ScoutFactory(family=family, status=Scout.INACTIVE)
     families.append(family)
 
@@ -35,7 +35,7 @@ print("Seeding calendar categories and events...")
 categories = [CategoryFactory() for _ in range(4)]
 for category in categories:
     for _ in range(5):
-        EventFactory(category=category, future=random.choice([True, False]))
+        EventFactory(category=category, future=random.choice([True, False]))  # nosec B311
 
 CurrentPackYearFactory()
 


### PR DESCRIPTION
Adds continue_in_same_den_from_last_year, a Scout admin action for assigning Cubs to their prior Pack Year's den once the year has already rolled over and they weren't pre-assigned ahead of time. Shares logic with the existing next-year rollover action via a new helper.

Also adds util/seed_dev_data.py, a factory_boy-based script for populating a local dev database with sample dens, families, and events.

## Summary by Sourcery

Add an admin action and shared helper to reassign Cubs to their prior-year dens after or during Pack Year rollover and introduce a script to seed local development data.

New Features:
- Add a Scout admin action to assign selected Cubs to the same den from the previous Pack Year into the current Pack Year.
- Introduce a shared helper for den rollover logic used by both next-year and previous-year reassignment actions.
- Add a factory_boy-based script to seed the local development database with sample dens, families, scouts, and events.

Enhancements:
- Refactor existing den rollover admin action to use the new shared helper and PackYear helpers for current and previous years.