### PR TITLE
Add gender column to Scout admin list display and sort by most recent…

### DIFF
--- a/packman/membership/admin.py
+++ b/packman/membership/admin.py
@@ -176,6 +176,7 @@ class ScoutAdmin(admin.ModelAdmin):
         "name",
         "last_name",
         "school",
+        "gender",
         "get_grade",
         "age",
         "status",

--- a/packman/membership/models.py
+++ b/packman/membership/models.py
@@ -446,6 +446,7 @@ class Scout(Member):
 
     class Meta:
         indexes = [models.Index(fields=["school", "family", "status", "started_school"])]
+        ordering = ["-date_added"]
         verbose_name = _("Cub")
         verbose_name_plural = _("Cubs")
 


### PR DESCRIPTION
- Add gender column to Scout admin table after school column
- Change Scout model default ordering to sort by date_added descending (most recent first)

## Summary by Sourcery

Add gender information to the Scout admin listing and update Scout records to be ordered by most recently added.

New Features:
- Display the gender field in the Scout admin list view.

Enhancements:
- Set the default Scout model ordering to sort by most recent date_added first.