### PR TITLE
Add GitHub Action to deploy branch to beta or prod

### DIFF
--- a/.github/workflows/deploy-beta.yml
+++ b/.github/workflows/deploy-beta.yml
@@ -1,4 +1,4 @@
-name: Deploy to Opalstack Beta
+name: Deploy to Beta
 
 # Manually triggered. Use the "Run workflow" button and pick the branch you
 # want to deploy — GitHub Actions will check that branch out to run this
@@ -13,10 +13,10 @@ jobs:
       - name: Deploy branch to beta via SSH
         uses: appleboy/ssh-action@v1
         with:
-          host: ${{ secrets.OPALSTACK_HOST }}
-          username: ${{ secrets.OPALSTACK_USERNAME }}
-          key: ${{ secrets.OPALSTACK_SSH_KEY }}
-          port: ${{ secrets.OPALSTACK_PORT || 22 }}
+          host: ${{ secrets.DEPLOY_HOST }}
+          username: ${{ secrets.DEPLOY_USERNAME }}
+          key: ${{ secrets.DEPLOY_SSH_KEY }}
+          port: ${{ secrets.DEPLOY_PORT || 22 }}
           script: |
             set -euo pipefail
             cd ~/apps/django-beta/packman

--- a/.github/workflows/deploy-beta.yml
+++ b/.github/workflows/deploy-beta.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   deploy-beta:
     runs-on: ubuntu-latest
+    environment: beta
     steps:
       - name: Deploy branch to beta via SSH
         uses: appleboy/ssh-action@v1

--- a/.github/workflows/deploy-beta.yml
+++ b/.github/workflows/deploy-beta.yml
@@ -6,31 +6,8 @@ name: Deploy to Beta
 on:
   workflow_dispatch:
 
-permissions:
-  contents: read
-
 jobs:
-  check-permission:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Verify actor has maintainer or admin access
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const { data } = await github.rest.repos.getCollaboratorPermissionLevel({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              username: context.actor,
-            });
-            const allowed = ["admin", "maintain"];
-            if (!allowed.includes(data.permission)) {
-              core.setFailed(
-                `@${context.actor} has '${data.permission}' access, but deploying to beta requires maintainer or admin access.`
-              );
-            }
-
   deploy-beta:
-    needs: check-permission
     runs-on: ubuntu-latest
     steps:
       - name: Deploy branch to beta via SSH

--- a/.github/workflows/deploy-beta.yml
+++ b/.github/workflows/deploy-beta.yml
@@ -13,10 +13,10 @@ jobs:
       - name: Deploy branch to beta via SSH
         uses: appleboy/ssh-action@v1
         with:
-          host: ${{ secrets.DEPLOY_HOST }}
-          username: ${{ secrets.DEPLOY_USERNAME }}
-          key: ${{ secrets.DEPLOY_SSH_KEY }}
-          port: ${{ secrets.DEPLOY_PORT || 22 }}
+          host: ${{ secrets.BETA_DEPLOY_HOST }}
+          username: ${{ secrets.BETA_DEPLOY_USERNAME }}
+          key: ${{ secrets.BETA_DEPLOY_SSH_KEY }}
+          port: ${{ secrets.BETA_DEPLOY_PORT || 22 }}
           script: |
             set -euo pipefail
             cd ~/apps/django-beta/packman

--- a/.github/workflows/deploy-beta.yml
+++ b/.github/workflows/deploy-beta.yml
@@ -6,8 +6,31 @@ name: Deploy to Beta
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
+  check-permission:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify actor has maintainer or admin access
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { data } = await github.rest.repos.getCollaboratorPermissionLevel({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              username: context.actor,
+            });
+            const allowed = ["admin", "maintain"];
+            if (!allowed.includes(data.permission)) {
+              core.setFailed(
+                `@${context.actor} has '${data.permission}' access, but deploying to beta requires maintainer or admin access.`
+              );
+            }
+
   deploy-beta:
+    needs: check-permission
     runs-on: ubuntu-latest
     steps:
       - name: Deploy branch to beta via SSH

--- a/.github/workflows/deploy-beta.yml
+++ b/.github/workflows/deploy-beta.yml
@@ -20,7 +20,14 @@ jobs:
           script: |
             set -euo pipefail
             cd ~/apps/django-beta/packman
-            git fetch origin
+            git fetch --prune origin
             git checkout "${{ github.ref_name }}"
             git pull origin "${{ github.ref_name }}"
+            # Clean up other local branches left over from previous deploys of
+            # different branches, so this checkout doesn't accumulate stale
+            # local refs over time. Only touches the local server checkout,
+            # not the GitHub repo itself.
+            git for-each-ref --format='%(refname:short)' refs/heads/ \
+              | grep -v -x "${{ github.ref_name }}" \
+              | xargs -r -n1 git branch -D
             util/deploy.sh --yes

--- a/.github/workflows/deploy-beta.yml
+++ b/.github/workflows/deploy-beta.yml
@@ -1,0 +1,26 @@
+name: Deploy to Opalstack Beta
+
+# Manually triggered. Use the "Run workflow" button and pick the branch you
+# want to deploy — GitHub Actions will check that branch out to run this
+# workflow, so `github.ref_name` below always refers to it.
+on:
+  workflow_dispatch:
+
+jobs:
+  deploy-beta:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy branch to beta via SSH
+        uses: appleboy/ssh-action@v1
+        with:
+          host: ${{ secrets.OPALSTACK_HOST }}
+          username: ${{ secrets.OPALSTACK_USERNAME }}
+          key: ${{ secrets.OPALSTACK_SSH_KEY }}
+          port: ${{ secrets.OPALSTACK_PORT || 22 }}
+          script: |
+            set -euo pipefail
+            cd ~/apps/django-beta/packman
+            git fetch origin
+            git checkout "${{ github.ref_name }}"
+            git pull origin "${{ github.ref_name }}"
+            util/deploy.sh --yes

--- a/.github/workflows/deploy-beta.yml
+++ b/.github/workflows/deploy-beta.yml
@@ -25,9 +25,9 @@ jobs:
             git pull origin "${{ github.ref_name }}"
             # Clean up other local branches left over from previous deploys of
             # different branches, so this checkout doesn't accumulate stale
-            # local refs over time. Only touches the local server checkout,
-            # not the GitHub repo itself.
+            # local refs over time. Keeps the branch just deployed and "main".
+            # Only touches the local server checkout, not the GitHub repo.
             git for-each-ref --format='%(refname:short)' refs/heads/ \
-              | grep -v -x "${{ github.ref_name }}" \
+              | grep -v -x -e "${{ github.ref_name }}" -e "main" \
               | xargs -r -n1 git branch -D
             util/deploy.sh --yes

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,26 +1,39 @@
-name: Deploy to Beta
+name: Deploy
 
-# Manually triggered. Use the "Run workflow" button and pick the branch you
-# want to deploy — GitHub Actions will check that branch out to run this
-# workflow, so `github.ref_name` below always refers to it.
+# Manually triggered. Use the "Run workflow" button, pick the branch you want
+# to deploy (github.ref_name below always refers to it), and choose which
+# environment to deploy to.
 on:
   workflow_dispatch:
+    inputs:
+      target:
+        description: Environment to deploy to
+        required: true
+        type: choice
+        default: beta
+        options:
+          - beta
+          - prod
 
 jobs:
-  deploy-beta:
+  deploy:
     runs-on: ubuntu-latest
-    environment: beta
+    environment: ${{ inputs.target }}
     steps:
-      - name: Deploy branch to beta via SSH
+      - name: Deploy branch via SSH
         uses: appleboy/ssh-action@v1
         with:
-          host: ${{ secrets.BETA_DEPLOY_HOST }}
-          username: ${{ secrets.BETA_DEPLOY_USERNAME }}
-          key: ${{ secrets.BETA_DEPLOY_SSH_KEY }}
-          port: ${{ secrets.BETA_DEPLOY_PORT || 22 }}
+          host: ${{ secrets.DEPLOY_HOST }}
+          username: ${{ secrets.DEPLOY_USERNAME }}
+          key: ${{ secrets.DEPLOY_SSH_KEY }}
+          port: ${{ secrets.DEPLOY_PORT || 22 }}
           script: |
             set -euo pipefail
-            cd ~/apps/django-beta/packman
+            if [ "${{ inputs.target }}" = "prod" ]; then
+              cd ~/apps/django/packman
+            else
+              cd ~/apps/django-beta/packman
+            fi
             git fetch --prune origin
             git checkout "${{ github.ref_name }}"
             git pull origin "${{ github.ref_name }}"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,6 +30,9 @@ jobs:
           script: |
             set -euo pipefail
             APP_DIR="${{ secrets.DEPLOY_APP_DIR }}"
+            # Secret values aren't shell-expanded, so a leading "~" in the
+            # secret wouldn't otherwise resolve to the home directory. Expand
+            # it manually here.
             APP_DIR="${APP_DIR/#\~/$HOME}"
             cd "$APP_DIR/packman"
             git fetch --prune origin

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,11 +29,8 @@ jobs:
           port: ${{ secrets.DEPLOY_PORT || 22 }}
           script: |
             set -euo pipefail
-            if [ "${{ inputs.target }}" = "prod" ]; then
-              APP_DIR=~/apps/django
-            else
-              APP_DIR=~/apps/django-beta
-            fi
+            APP_DIR="${{ secrets.DEPLOY_APP_DIR }}"
+            APP_DIR="${APP_DIR/#\~/$HOME}"
             cd "$APP_DIR/packman"
             git fetch --prune origin
             git checkout "${{ github.ref_name }}"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,10 +30,11 @@ jobs:
           script: |
             set -euo pipefail
             if [ "${{ inputs.target }}" = "prod" ]; then
-              cd ~/apps/django/packman
+              APP_DIR=~/apps/django
             else
-              cd ~/apps/django-beta/packman
+              APP_DIR=~/apps/django-beta
             fi
+            cd "$APP_DIR/packman"
             git fetch --prune origin
             git checkout "${{ github.ref_name }}"
             git pull origin "${{ github.ref_name }}"
@@ -44,4 +45,4 @@ jobs:
             git for-each-ref --format='%(refname:short)' refs/heads/ \
               | grep -v -x -e "${{ github.ref_name }}" -e "main" \
               | xargs -r -n1 git branch -D
-            util/deploy.sh --yes
+            util/deploy.sh --app-dir "$APP_DIR" --yes

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -45,4 +45,4 @@ jobs:
             git for-each-ref --format='%(refname:short)' refs/heads/ \
               | grep -v -x -e "${{ github.ref_name }}" -e "main" \
               | xargs -r -n1 git branch -D
-            util/deploy.sh --app-dir "$APP_DIR"
+            util/deploy.sh "$APP_DIR"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -45,4 +45,4 @@ jobs:
             git for-each-ref --format='%(refname:short)' refs/heads/ \
               | grep -v -x -e "${{ github.ref_name }}" -e "main" \
               | xargs -r -n1 git branch -D
-            util/deploy.sh --app-dir "$APP_DIR" --yes
+            util/deploy.sh --app-dir "$APP_DIR"

--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ Note: beta and prod share a database, the deployment to beta will also run any m
 ```bash
 cd ~/apps/django-beta/packman
 git pull
-util/deploy.sh --app-dir ~/apps/django-beta
+util/deploy.sh ~/apps/django-beta
 ```
 
 After validation switch to the prod directory and repeat.

--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ runs [deploy.sh](util/deploy.sh).
 This requires the following repository secrets to be configured under
 *Settings → Secrets and variables → Actions*:
 
-* `DEPLOY_HOST` — SSH host for the beta server
-* `DEPLOY_USERNAME` — SSH username
-* `DEPLOY_SSH_KEY` — private key with access to the beta deployment
-* `DEPLOY_PORT` — *(optional)* SSH port, defaults to `22`
+* `BETA_DEPLOY_HOST` — SSH host for the beta server
+* `BETA_DEPLOY_USERNAME` — SSH username
+* `BETA_DEPLOY_SSH_KEY` — private key with access to the beta deployment
+* `BETA_DEPLOY_PORT` — *(optional)* SSH port, defaults to `22`

--- a/README.md
+++ b/README.md
@@ -201,7 +201,9 @@ Instead of SSHing in manually, you can deploy any branch to beta from the
 [Deploy to Beta](.github/workflows/deploy-beta.yml) workflow: go to
 the *Actions* tab, select it, click *Run workflow*, and pick the branch to
 deploy. It SSHes into the beta server, checks out the selected branch, and
-runs [deploy.sh](util/deploy.sh).
+runs [deploy.sh](util/deploy.sh). Only repository collaborators with
+maintainer or admin access can run it; the workflow checks the triggering
+user's permission level and fails otherwise.
 
 This requires the following repository secrets to be configured under
 *Settings → Secrets and variables → Actions*:

--- a/README.md
+++ b/README.md
@@ -210,3 +210,9 @@ This requires the following repository secrets to be configured under
 * `BETA_DEPLOY_USERNAME` — SSH username
 * `BETA_DEPLOY_SSH_KEY` — private key with access to the beta deployment
 * `BETA_DEPLOY_PORT` — *(optional)* SSH port, defaults to `22`
+
+The deploy job runs against the `beta` [GitHub
+environment](https://docs.github.com/actions/deployment/targeting-different-environments/using-environments-for-deployment).
+Create a `beta` environment under *Settings → Environments* and add
+required reviewers there to gate who can approve a deployment run; the
+secrets above can also be scoped to that environment instead of the repo.

--- a/README.md
+++ b/README.md
@@ -201,9 +201,7 @@ Instead of SSHing in manually, you can deploy any branch to beta from the
 [Deploy to Beta](.github/workflows/deploy-beta.yml) workflow: go to
 the *Actions* tab, select it, click *Run workflow*, and pick the branch to
 deploy. It SSHes into the beta server, checks out the selected branch, and
-runs [deploy.sh](util/deploy.sh). Only repository collaborators with
-maintainer or admin access can run it; the workflow checks the triggering
-user's permission level and fails otherwise.
+runs [deploy.sh](util/deploy.sh).
 
 This requires the following repository secrets to be configured under
 *Settings → Secrets and variables → Actions*:

--- a/README.md
+++ b/README.md
@@ -188,8 +188,13 @@ Note: beta and prod share a database, the deployment to beta will also run any m
 ```bash
 cd ~/apps/django-beta/packman
 git pull
-util/deploy.sh ~/apps/django-beta
+util/deploy.sh
 ```
+
+If `APP_DIR` is omitted, `deploy.sh` will detect it from the current
+directory when run from `$HOME/apps/<app-dir>/packman` and prompt for
+confirmation before continuing. You can also pass it explicitly (from
+anywhere) with `util/deploy.sh ~/apps/django-beta`.
 
 After validation switch to the prod directory and repeat.
 

--- a/README.md
+++ b/README.md
@@ -195,24 +195,27 @@ After validation switch to the prod directory and repeat.
 
 See the [deploy.sh](util/deploy.sh) for more details on how the deployment works.
 
-#### Deploying to beta via GitHub Actions
+#### Deploying via GitHub Actions
 
-Instead of SSHing in manually, you can deploy any branch to beta from the
-[Deploy to Beta](.github/workflows/deploy-beta.yml) workflow: go to
-the *Actions* tab, select it, click *Run workflow*, and pick the branch to
-deploy. It SSHes into the beta server, checks out the selected branch, and
-runs [deploy.sh](util/deploy.sh).
+Instead of SSHing in manually, you can deploy any branch to beta or prod
+from the [Deploy](.github/workflows/deploy.yml) workflow: go to the
+*Actions* tab, select it, click *Run workflow*, pick the branch to deploy,
+and choose the `target` environment (`beta` or `prod`). It SSHes into the
+corresponding server, checks out the selected branch, and runs
+[deploy.sh](util/deploy.sh).
 
-This requires the following repository secrets to be configured under
-*Settings → Secrets and variables → Actions*:
+This requires the following secrets to be configured (per environment,
+under *Settings → Environments → beta/prod*, or as repository-level
+secrets under *Settings → Secrets and variables → Actions* if you don't
+need different values per environment):
 
-* `BETA_DEPLOY_HOST` — SSH host for the beta server
-* `BETA_DEPLOY_USERNAME` — SSH username
-* `BETA_DEPLOY_SSH_KEY` — private key with access to the beta deployment
-* `BETA_DEPLOY_PORT` — *(optional)* SSH port, defaults to `22`
+* `DEPLOY_HOST` — SSH host for the target server
+* `DEPLOY_USERNAME` — SSH username
+* `DEPLOY_SSH_KEY` — private key with access to the target deployment
+* `DEPLOY_PORT` — *(optional)* SSH port, defaults to `22`
 
-The deploy job runs against the `beta` [GitHub
+The deploy job runs against the selected `beta` or `prod` [GitHub
 environment](https://docs.github.com/actions/deployment/targeting-different-environments/using-environments-for-deployment).
-Create a `beta` environment under *Settings → Environments* and add
-required reviewers there to gate who can approve a deployment run; the
-secrets above can also be scoped to that environment instead of the repo.
+Create `beta` and `prod` environments under *Settings → Environments* and
+add required reviewers there to gate who can approve a deployment run to
+each one — this is especially important for `prod`.

--- a/README.md
+++ b/README.md
@@ -204,15 +204,18 @@ and choose the `target` environment (`beta` or `prod`). It SSHes into the
 corresponding server, checks out the selected branch, and runs
 [deploy.sh](util/deploy.sh).
 
-This requires the following secrets to be configured (per environment,
-under *Settings → Environments → beta/prod*, or as repository-level
-secrets under *Settings → Secrets and variables → Actions* if you don't
-need different values per environment):
+This requires the following secrets to be configured per environment under
+*Settings → Environments → beta/prod* (the `DEPLOY_HOST` et al. secrets can
+also be repository-level if you don't need different values per
+environment, but `DEPLOY_APP_DIR` must be set per environment since beta
+and prod point to different directories):
 
 * `DEPLOY_HOST` — SSH host for the target server
 * `DEPLOY_USERNAME` — SSH username
 * `DEPLOY_SSH_KEY` — private key with access to the target deployment
 * `DEPLOY_PORT` — *(optional)* SSH port, defaults to `22`
+* `DEPLOY_APP_DIR` — app directory on the server to deploy
+  (e.g. `~/apps/django-beta` for beta, `~/apps/django` for prod)
 
 The deploy job runs against the selected `beta` or `prod` [GitHub
 environment](https://docs.github.com/actions/deployment/targeting-different-environments/using-environments-for-deployment).

--- a/README.md
+++ b/README.md
@@ -201,6 +201,10 @@ Instead of SSHing in manually, you can deploy any branch to beta from the
 [Deploy to Beta](.github/workflows/deploy-beta.yml) workflow: go to
 the *Actions* tab, select it, click *Run workflow*, and pick the branch to
 deploy. It SSHes into the beta server and runs the same steps shown above.
+After checking out and pulling the selected branch, it also deletes any
+other local branches left in that server-side checkout from previous
+deploys, so it doesn't accumulate stale branches over time (this only
+affects the local checkout on the server, not the GitHub repo).
 
 This requires the following repository secrets to be configured under
 *Settings → Secrets and variables → Actions*:

--- a/README.md
+++ b/README.md
@@ -200,12 +200,8 @@ See the [deploy.sh](util/deploy.sh) for more details on how the deployment works
 Instead of SSHing in manually, you can deploy any branch to beta from the
 [Deploy to Beta](.github/workflows/deploy-beta.yml) workflow: go to
 the *Actions* tab, select it, click *Run workflow*, and pick the branch to
-deploy. It SSHes into the beta server and runs the same steps shown above.
-After checking out and pulling the selected branch, it also deletes any
-other local branches left in that server-side checkout from previous
-deploys (keeping `main`), so it doesn't accumulate stale branches over
-time (this only affects the local checkout on the server, not the GitHub
-repo).
+deploy. It SSHes into the beta server, checks out the selected branch, and
+runs [deploy.sh](util/deploy.sh).
 
 This requires the following repository secrets to be configured under
 *Settings → Secrets and variables → Actions*:

--- a/README.md
+++ b/README.md
@@ -209,21 +209,9 @@ and choose the `target` environment (`beta` or `prod`). It SSHes into the
 corresponding server, checks out the selected branch, and runs
 [deploy.sh](util/deploy.sh).
 
-This requires the following secrets to be configured per environment under
-*Settings → Environments → beta/prod* (the `DEPLOY_HOST` et al. secrets can
-also be repository-level if you don't need different values per
-environment, but `DEPLOY_APP_DIR` must be set per environment since beta
-and prod point to different directories):
-
+This requires the following secrets to be configured.
 * `DEPLOY_HOST` — SSH host for the target server
 * `DEPLOY_USERNAME` — SSH username
 * `DEPLOY_SSH_KEY` — private key with access to the target deployment
 * `DEPLOY_PORT` — *(optional)* SSH port, defaults to `22`
 * `DEPLOY_APP_DIR` — app directory on the server to deploy
-  (e.g. `~/apps/django-beta` for beta, `~/apps/django` for prod)
-
-The deploy job runs against the selected `beta` or `prod` [GitHub
-environment](https://docs.github.com/actions/deployment/targeting-different-environments/using-environments-for-deployment).
-Create `beta` and `prod` environments under *Settings → Environments* and
-add required reviewers there to gate who can approve a deployment run to
-each one — this is especially important for `prod`.

--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ Note: beta and prod share a database, the deployment to beta will also run any m
 ```bash
 cd ~/apps/django-beta/packman
 git pull
-util/deploy.sh
+util/deploy.sh --app-dir ~/apps/django-beta
 ```
 
 After validation switch to the prod directory and repeat.

--- a/README.md
+++ b/README.md
@@ -198,14 +198,14 @@ See the [deploy.sh](util/deploy.sh) for more details on how the deployment works
 #### Deploying to beta via GitHub Actions
 
 Instead of SSHing in manually, you can deploy any branch to beta from the
-[Deploy to Opalstack Beta](.github/workflows/deploy-beta.yml) workflow: go to
+[Deploy to Beta](.github/workflows/deploy-beta.yml) workflow: go to
 the *Actions* tab, select it, click *Run workflow*, and pick the branch to
-deploy. It SSHes into Opalstack and runs the same steps shown above.
+deploy. It SSHes into the beta server and runs the same steps shown above.
 
 This requires the following repository secrets to be configured under
 *Settings → Secrets and variables → Actions*:
 
-* `OPALSTACK_HOST` — SSH host for the Opalstack server
-* `OPALSTACK_USERNAME` — SSH username
-* `OPALSTACK_SSH_KEY` — private key with access to the beta deployment
-* `OPALSTACK_PORT` — *(optional)* SSH port, defaults to `22`
+* `DEPLOY_HOST` — SSH host for the beta server
+* `DEPLOY_USERNAME` — SSH username
+* `DEPLOY_SSH_KEY` — private key with access to the beta deployment
+* `DEPLOY_PORT` — *(optional)* SSH port, defaults to `22`

--- a/README.md
+++ b/README.md
@@ -194,3 +194,18 @@ util/deploy.sh
 After validation switch to the prod directory and repeat.
 
 See the [deploy.sh](util/deploy.sh) for more details on how the deployment works.
+
+#### Deploying to beta via GitHub Actions
+
+Instead of SSHing in manually, you can deploy any branch to beta from the
+[Deploy to Opalstack Beta](.github/workflows/deploy-beta.yml) workflow: go to
+the *Actions* tab, select it, click *Run workflow*, and pick the branch to
+deploy. It SSHes into Opalstack and runs the same steps shown above.
+
+This requires the following repository secrets to be configured under
+*Settings → Secrets and variables → Actions*:
+
+* `OPALSTACK_HOST` — SSH host for the Opalstack server
+* `OPALSTACK_USERNAME` — SSH username
+* `OPALSTACK_SSH_KEY` — private key with access to the beta deployment
+* `OPALSTACK_PORT` — *(optional)* SSH port, defaults to `22`

--- a/README.md
+++ b/README.md
@@ -203,8 +203,9 @@ the *Actions* tab, select it, click *Run workflow*, and pick the branch to
 deploy. It SSHes into the beta server and runs the same steps shown above.
 After checking out and pulling the selected branch, it also deletes any
 other local branches left in that server-side checkout from previous
-deploys, so it doesn't accumulate stale branches over time (this only
-affects the local checkout on the server, not the GitHub repo).
+deploys (keeping `main`), so it doesn't accumulate stale branches over
+time (this only affects the local checkout on the server, not the GitHub
+repo).
 
 This requires the following repository secrets to be configured under
 *Settings → Secrets and variables → Actions*:

--- a/util/deploy.sh
+++ b/util/deploy.sh
@@ -33,9 +33,8 @@ fi
 
 # Resolve to an absolute path
 APP_DIR="$(cd "$APP_DIR" && pwd -P)"
-STAGE="$(basename "$APP_DIR")"
 
-echo "Deploying '$STAGE' ($APP_DIR)"
+echo "Deploying ($APP_DIR)"
 
 cd "$APP_DIR/packman"
 

--- a/util/deploy.sh
+++ b/util/deploy.sh
@@ -3,7 +3,7 @@
 # Exit immediately if a command exits with a non-zero status
 set -euo pipefail
 
-APPS_DIR="/home/pack144/apps"
+APPS_DIR="$HOME/apps"
 PROD_APP_DIR="$APPS_DIR/django"
 PROD_PACKMAN_DIR="$PROD_APP_DIR/packman"
 BETA_APP_DIR="$APPS_DIR/django-beta"

--- a/util/deploy.sh
+++ b/util/deploy.sh
@@ -3,45 +3,7 @@
 # Exit immediately if a command exits with a non-zero status
 set -euo pipefail
 
-usage() {
-    cat <<'USAGE'
-Usage: util/deploy.sh --app-dir DIR
-
-  --app-dir DIR   Path to the app directory containing the "env" virtualenv
-                  and "packman" git checkout (e.g. ~/apps/django-beta)
-  -h, --help      Show this help message
-USAGE
-}
-
-APP_DIR=""
-
-while [[ $# -gt 0 ]]; do
-    case "$1" in
-        --app-dir)
-            APP_DIR="${2:-}"
-            shift 2
-            ;;
-        --app-dir=*)
-            APP_DIR="${1#*=}"
-            shift
-            ;;
-        -h|--help)
-            usage
-            exit 0
-            ;;
-        *)
-            echo "Error: Unknown argument: $1" >&2
-            usage
-            exit 2
-            ;;
-    esac
-done
-
-if [[ -z "$APP_DIR" ]]; then
-    echo "Error: --app-dir is required" >&2
-    usage
-    exit 2
-fi
+APP_DIR="${1:?Usage: util/deploy.sh APP_DIR}"
 
 if [[ ! -d "$APP_DIR/packman" ]]; then
     echo "Error: '$APP_DIR/packman' does not exist" >&2

--- a/util/deploy.sh
+++ b/util/deploy.sh
@@ -3,41 +3,66 @@
 # Exit immediately if a command exits with a non-zero status
 set -euo pipefail
 
-APPS_DIR="$HOME/apps"
-PROD_APP_DIR="$APPS_DIR/django"
-PROD_PACKMAN_DIR="$PROD_APP_DIR/packman"
-BETA_APP_DIR="$APPS_DIR/django-beta"
-BETA_PACKMAN_DIR="$BETA_APP_DIR/packman"
+usage() {
+    cat <<'USAGE'
+Usage: util/deploy.sh --app-dir DIR [-y|--yes]
 
-CURRENT_DIR="$(pwd -P)"
+  --app-dir DIR   Path to the app directory containing the "env" virtualenv
+                  and "packman" git checkout (e.g. ~/apps/django-beta)
+  -y, --yes       Skip the interactive confirmation prompt (e.g. from CI)
+  -h, --help      Show this help message
+USAGE
+}
 
-# Allow skipping the confirmation prompt (e.g. from CI) via -y/--yes
+APP_DIR=""
 ASSUME_YES=false
-for arg in "$@"; do
-    case "$arg" in
-        -y|--yes) ASSUME_YES=true ;;
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --app-dir)
+            APP_DIR="${2:-}"
+            shift 2
+            ;;
+        --app-dir=*)
+            APP_DIR="${1#*=}"
+            shift
+            ;;
+        -y|--yes)
+            ASSUME_YES=true
+            shift
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "Error: Unknown argument: $1" >&2
+            usage
+            exit 2
+            ;;
     esac
 done
 
-# Verify directory and identify stage
-if [[ "$CURRENT_DIR" == "$PROD_PACKMAN_DIR" ]]; then
-    STAGE="prod"
-    APP_DIR="$PROD_APP_DIR"
-elif [[ "$CURRENT_DIR" == "$BETA_PACKMAN_DIR" ]]; then
-    STAGE="beta"
-    APP_DIR="$BETA_APP_DIR"
-else
-    echo "Error: This script must be run from:"
-    echo "   $PROD_PACKMAN_DIR"
-    echo "   $BETA_PACKMAN_DIR"
+if [[ -z "$APP_DIR" ]]; then
+    echo "Error: --app-dir is required" >&2
+    usage
     exit 2
 fi
 
+if [[ ! -d "$APP_DIR/packman" ]]; then
+    echo "Error: '$APP_DIR/packman' does not exist" >&2
+    exit 2
+fi
+
+# Resolve to an absolute path
+APP_DIR="$(cd "$APP_DIR" && pwd -P)"
+STAGE="$(basename "$APP_DIR")"
+
 # Ask user for confirmation (skipped when -y/--yes is passed, e.g. from CI)
 if [[ "$ASSUME_YES" == true ]]; then
-    echo "⚠️  You are in the '$STAGE' environment. Proceeding with deployment (--yes)."
+    echo "⚠️  Deploying '$STAGE' ($APP_DIR). Proceeding with deployment (--yes)."
 else
-    read -rp "⚠️  You are in the '$STAGE' environment. Proceed with deployment? (y/N): " CONFIRM
+    read -rp "⚠️  You are about to deploy '$STAGE' ($APP_DIR). Proceed with deployment? (y/N): " CONFIRM
     CONFIRM="${CONFIRM,,}"  # Convert to lowercase
 
     if [[ "$CONFIRM" != "y" && "$CONFIRM" != "yes" ]]; then
@@ -46,14 +71,16 @@ else
     fi
 fi
 
+cd "$APP_DIR/packman"
+
 echo "Updating dependencies"
 UV_PROJECT_ENVIRONMENT="$APP_DIR/env" uv sync --group production
 
 echo "Running database migrations"
-$APP_DIR/env/bin/python manage.py migrate
+"$APP_DIR/env/bin/python" manage.py migrate
 
 echo "Collecting any new static files"
-DJANGO_SETTINGS_MODULE=packman.settings.production $APP_DIR/env/bin/python manage.py collectstatic --no-input
+DJANGO_SETTINGS_MODULE=packman.settings.production "$APP_DIR/env/bin/python" manage.py collectstatic --no-input
 
 echo "Initiating server restart"
-touch $APP_DIR/packman/packman/wsgi.py
+touch "$APP_DIR/packman/packman/wsgi.py"

--- a/util/deploy.sh
+++ b/util/deploy.sh
@@ -5,17 +5,15 @@ set -euo pipefail
 
 usage() {
     cat <<'USAGE'
-Usage: util/deploy.sh --app-dir DIR [-y|--yes]
+Usage: util/deploy.sh --app-dir DIR
 
   --app-dir DIR   Path to the app directory containing the "env" virtualenv
                   and "packman" git checkout (e.g. ~/apps/django-beta)
-  -y, --yes       Skip the interactive confirmation prompt (e.g. from CI)
   -h, --help      Show this help message
 USAGE
 }
 
 APP_DIR=""
-ASSUME_YES=false
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -25,10 +23,6 @@ while [[ $# -gt 0 ]]; do
             ;;
         --app-dir=*)
             APP_DIR="${1#*=}"
-            shift
-            ;;
-        -y|--yes)
-            ASSUME_YES=true
             shift
             ;;
         -h|--help)
@@ -58,18 +52,7 @@ fi
 APP_DIR="$(cd "$APP_DIR" && pwd -P)"
 STAGE="$(basename "$APP_DIR")"
 
-# Ask user for confirmation (skipped when -y/--yes is passed, e.g. from CI)
-if [[ "$ASSUME_YES" == true ]]; then
-    echo "⚠️  Deploying '$STAGE' ($APP_DIR). Proceeding with deployment (--yes)."
-else
-    read -rp "⚠️  You are about to deploy '$STAGE' ($APP_DIR). Proceed with deployment? (y/N): " CONFIRM
-    CONFIRM="${CONFIRM,,}"  # Convert to lowercase
-
-    if [[ "$CONFIRM" != "y" && "$CONFIRM" != "yes" ]]; then
-        echo "Operation cancelled by user."
-        exit 3
-    fi
-fi
+echo "Deploying '$STAGE' ($APP_DIR)"
 
 cd "$APP_DIR/packman"
 

--- a/util/deploy.sh
+++ b/util/deploy.sh
@@ -11,6 +11,14 @@ BETA_PACKMAN_DIR="$BETA_APP_DIR/packman"
 
 CURRENT_DIR="$(pwd -P)"
 
+# Allow skipping the confirmation prompt (e.g. from CI) via -y/--yes
+ASSUME_YES=false
+for arg in "$@"; do
+    case "$arg" in
+        -y|--yes) ASSUME_YES=true ;;
+    esac
+done
+
 # Verify directory and identify stage
 if [[ "$CURRENT_DIR" == "$PROD_PACKMAN_DIR" ]]; then
     STAGE="prod"
@@ -25,13 +33,17 @@ else
     exit 2
 fi
 
-# Ask user for confirmation
-read -rp "⚠️  You are in the '$STAGE' environment. Proceed with deployment? (y/N): " CONFIRM
-CONFIRM="${CONFIRM,,}"  # Convert to lowercase
+# Ask user for confirmation (skipped when -y/--yes is passed, e.g. from CI)
+if [[ "$ASSUME_YES" == true ]]; then
+    echo "⚠️  You are in the '$STAGE' environment. Proceeding with deployment (--yes)."
+else
+    read -rp "⚠️  You are in the '$STAGE' environment. Proceed with deployment? (y/N): " CONFIRM
+    CONFIRM="${CONFIRM,,}"  # Convert to lowercase
 
-if [[ "$CONFIRM" != "y" && "$CONFIRM" != "yes" ]]; then
-    echo "Operation cancelled by user."
-    exit 3
+    if [[ "$CONFIRM" != "y" && "$CONFIRM" != "yes" ]]; then
+        echo "Operation cancelled by user."
+        exit 3
+    fi
 fi
 
 echo "Updating dependencies"

--- a/util/deploy.sh
+++ b/util/deploy.sh
@@ -3,7 +3,28 @@
 # Exit immediately if a command exits with a non-zero status
 set -euo pipefail
 
-APP_DIR="${1:?Usage: util/deploy.sh APP_DIR}"
+if [[ $# -ge 1 ]]; then
+    APP_DIR="$1"
+else
+    # No APP_DIR given — see if we're already sitting in
+    # $HOME/apps/<app-dir>/packman and offer to use that.
+    APPS_DIR="$HOME/apps"
+    CURRENT_DIR="$(pwd -P)"
+
+    if [[ "$CURRENT_DIR" == "$APPS_DIR"/*/packman ]]; then
+        APP_DIR="${CURRENT_DIR%/packman}"
+        read -rp "⚠️  No APP_DIR given; detected '$APP_DIR' from the current directory. Continue? (y/N): " CONFIRM
+        CONFIRM="${CONFIRM,,}"  # Convert to lowercase
+
+        if [[ "$CONFIRM" != "y" && "$CONFIRM" != "yes" ]]; then
+            echo "Operation cancelled by user."
+            exit 3
+        fi
+    else
+        echo "Usage: util/deploy.sh APP_DIR" >&2
+        exit 1
+    fi
+fi
 
 if [[ ! -d "$APP_DIR/packman" ]]; then
     echo "Error: '$APP_DIR/packman' does not exist" >&2


### PR DESCRIPTION
## Summary

Adds a manually-triggered GitHub Action (`workflow_dispatch`) that SSHes into a server and deploys whichever branch is selected when running the workflow, to either the **beta** or **prod** environment (chosen via an input), as an alternative to SSHing in and running `util/deploy.sh` by hand.

## Changes

- **`.github/workflows/deploy.yml`** — new workflow. Takes a `target` choice input (`beta`/`prod`, default `beta`). Uses `appleboy/ssh-action` to SSH into the corresponding server, fetch/checkout/pull the selected branch (`github.ref_name`), clean up other stale local branches left over from previous deploys (keeping `main` and the branch just deployed — only affects the server-side checkout, not the GitHub repo), and run `util/deploy.sh --yes`. The job runs against the `beta` or `prod` GitHub environment matching the chosen target.
- **`util/deploy.sh`**:
  - Added a `-y`/`--yes` flag to skip the interactive confirmation prompt so it can run non-interactively from CI. Manual/local usage is unchanged (still prompts by default).
  - Replaced the hard-coded `/home/pack144/apps` with `$HOME/apps` so the script works for any deploy user.
- **`README.md`** — documents the new workflow and the required secrets/environments.

## Required setup

- Secrets `DEPLOY_HOST`, `DEPLOY_USERNAME`, `DEPLOY_SSH_KEY`, and optional `DEPLOY_PORT` (defaults to 22) — configure these per-environment under *Settings → Environments → beta/prod* so beta and prod can use different servers/credentials (or as repo-level secrets if you don't need that distinction).
- Create `beta` and `prod` environments under *Settings → Environments* and add required reviewers there to gate who can approve deployments — especially recommended for `prod`.

## Testing

- `bash -n util/deploy.sh` and YAML validation on the workflow file.
- Smoke-tested `deploy.sh --yes` (confirmation prompt correctly skipped) and the `$HOME`-based path resolution against a local fake directory structure.
- Verified the stale-branch cleanup logic in an isolated git repo (deletes other branches, preserves `main` and the deployed branch).
- Verified the `target` → remote directory conditional logic (`beta`/`prod`) locally.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>

## Summary by Sourcery

Enable manually triggered branch deployments to beta or production through GitHub Actions while making the deployment script CI-ready.

New Features:
- Add a manually triggered GitHub Actions workflow for deploying a selected branch to beta or production environments with environment-specific credentials and approval gates.

Enhancements:
- Make the deployment script accept an explicit application directory and support non-interactive execution while retaining confirmation for manual deployments.
- Improve deployment path handling so it works with the deploying user's home directory and safely handles paths and command arguments.

CI:
- Add the deployment workflow and document its required secrets and GitHub environment configuration.

Deployment:
- Enable branch-based beta and production deployments over SSH, including cleanup of stale server-side branches before running the deployment.

Documentation:
- Document how to run deployments through GitHub Actions and configure deployment secrets and environment reviewers.
