### PR TITLE
Rename deploy action secrets to SERVICE_* naming

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,13 +23,13 @@ jobs:
       - name: Deploy branch via SSH
         uses: appleboy/ssh-action@v1
         with:
-          host: ${{ secrets.DEPLOY_HOST }}
-          username: ${{ secrets.DEPLOY_USERNAME }}
-          key: ${{ secrets.DEPLOY_SSH_KEY }}
-          port: ${{ secrets.DEPLOY_PORT || 22 }}
+          host: ${{ secrets.SERVICE_HOST }}
+          username: ${{ secrets.SERVICE_SSH_USERNAME }}
+          key: ${{ secrets.SERVICE_AUTHORIZED_SSH_KEY }}
+          port: ${{ secrets.SERVICE_SSH_PORT || 22 }}
           script: |
             set -euo pipefail
-            APP_DIR="${{ secrets.DEPLOY_APP_DIR }}"
+            APP_DIR="${{ secrets.SERVICE_APP_DIR }}"
             # Secret values aren't shell-expanded, so a leading "~" in the
             # secret wouldn't otherwise resolve to the home directory. Expand
             # it manually here.

--- a/README.md
+++ b/README.md
@@ -210,8 +210,8 @@ corresponding server, checks out the selected branch, and runs
 [deploy.sh](util/deploy.sh).
 
 This requires the following secrets to be configured.
-* `DEPLOY_HOST` — SSH host for the target server
-* `DEPLOY_USERNAME` — SSH username
-* `DEPLOY_SSH_KEY` — private key with access to the target deployment
-* `DEPLOY_PORT` — *(optional)* SSH port, defaults to `22`
-* `DEPLOY_APP_DIR` — app directory on the server to deploy
+* `SERVICE_HOST` — SSH host for the target server
+* `SERVICE_SSH_USERNAME` — SSH username
+* `SERVICE_AUTHORIZED_SSH_KEY` — private key with access to the target deployment
+* `SERVICE_SSH_PORT` — *(optional)* SSH port, defaults to `22`
+* `SERVICE_APP_DIR` — app directory on the server to deploy

--- a/README.md
+++ b/README.md
@@ -191,11 +191,6 @@ git pull
 util/deploy.sh
 ```
 
-If `APP_DIR` is omitted, `deploy.sh` will detect it from the current
-directory when run from `$HOME/apps/<app-dir>/packman` and prompt for
-confirmation before continuing. You can also pass it explicitly (from
-anywhere) with `util/deploy.sh ~/apps/django-beta`.
-
 After validation switch to the prod directory and repeat.
 
 See the [deploy.sh](util/deploy.sh) for more details on how the deployment works.


### PR DESCRIPTION
Renames the GitHub Actions deploy secrets used in `.github/workflows/deploy.yml` and documented in `README.md`:

| Old | New |
|---|---|
| `DEPLOY_HOST` | `SERVICE_HOST` |
| `DEPLOY_SSH_KEY` | `SERVICE_AUTHORIZED_SSH_KEY` |
| `DEPLOY_PORT` | `SERVICE_SSH_PORT` |
| `DEPLOY_APP_DIR` | `SERVICE_APP_DIR` |
| `DEPLOY_USERNAME` | `SERVICE_SSH_USERNAME` |

No logic changes — pure identifier rename.

**Action required:** the corresponding secrets must be renamed in the repo's Settings → Secrets and variables → Actions to match, or the `deploy.yml` workflow will fail on its next run.

## Summary by Sourcery

Standardize deployment secret names under the `SERVICE_*` convention.

Enhancements:
- Rename deployment workflow secrets to the `SERVICE_*` naming scheme and update the documented configuration names accordingly.

Deployment:
- Update the deployment workflow to use the renamed service connection and application directory secrets.

Documentation:
- Update deployment documentation to list the new service secret names.