### PR TITLE
Use dual y-axes for order report chart

### DIFF
--- a/packman/campaigns/templates/campaigns/order_report.html
+++ b/packman/campaigns/templates/campaigns/order_report.html
@@ -159,12 +159,14 @@
             label: "Count",
             backgroundColor: "rgb(99, 132, 255)",
             borderColor: "rgb(99, 132, 255)",
+            yAxisID: "y",
             data: [{% for day in report.days %}"{{ day.count }}"{% if not forloop.last %}, {% endif %}{% endfor %}]
           },
           {
             label: "Total $",
             backgroundColor: 'rgb(255, 99, 132)',
             borderColor: 'rgb(255, 99, 132)',
+            yAxisID: "y1",
             data: [{% for day in report.days %}"{{ day.order_total }}"{% if not forloop.last %}, {% endif %}{% endfor %}]
           }
         ]
@@ -173,7 +175,29 @@
       const config = {
         type: "bar",
         data: data,
-        options: {}
+        options: {
+          scales: {
+            y: {
+              type: "linear",
+              position: "left",
+              title: {
+                display: true,
+                text: "Order Count"
+              }
+            },
+            y1: {
+              type: "linear",
+              position: "right",
+              title: {
+                display: true,
+                text: "Total $"
+              },
+              grid: {
+                drawOnChartArea: false
+              }
+            }
+          }
+        }
       };
 
       const myChar = new Chart(


### PR DESCRIPTION
## Summary
The "Daily Order Breakdown" chart on the Order Report page (`ncc/`) plotted order count and total dollar amount on the same y-axis, making the two very differently-scaled datasets hard to read together.

## Changes
- `packman/campaigns/templates/campaigns/order_report.html`: assign the "Count" dataset to a left axis (`y`, labeled "Order Count") and the "Total $" dataset to a right axis (`y1`, labeled "Total $"), disabling gridlines on the right axis to avoid clutter.

## Testing
- `uv run python manage.py test tests.campaigns.test_reports` — all 10 tests pass.

## Summary by Sourcery

Use dual y-axes to make order counts and total amounts easier to compare in the order report chart.

Bug Fixes:
- Improve readability of the Daily Order Breakdown chart by separating order counts and total dollar amounts onto independent y-axes.

Enhancements:
- Label the chart axes by metric and reduce visual clutter on the secondary axis.