### PR TITLE
Default Orders, Prizes, and Products admin lists to the latest campaign

### DIFF
--- a/packman/campaigns/admin.py
+++ b/packman/campaigns/admin.py
@@ -21,6 +21,21 @@ from .models import (
 
 
 class CampaignFilter(admin.SimpleListFilter):
+    """
+    A drop-in replacement for the default "campaign" FK list filter.
+
+    We use a custom filter (instead of just listing "campaign" in
+    ``list_filter``) so that Orders, Prizes, and Products default to showing
+    only the latest campaign when an admin first opens the changelist,
+    rather than dumping every campaign's data on screen at once. The stock
+    FK filter has no concept of a "default" selection: with no query
+    param present it always means "show everything", and its "All" choice
+    works by removing the param entirely - which is indistinguishable from
+    the un-filtered initial state. To get a real default we have to own
+    both `queryset()` (decide what "no param" means) and `choices()`
+    (make "All" its own distinct, stateful choice).
+    """
+
     title = _("campaign")
     parameter_name = "campaign__id__exact"
 
@@ -30,13 +45,24 @@ class CampaignFilter(admin.SimpleListFilter):
     def queryset(self, request, queryset):
         value = self.value()
         if value == "all":
+            # Explicit "All" was chosen from the filter sidebar - show everything.
             return queryset
         if value in (None, ""):
+            # No filter param at all means this is the first, unfiltered load of
+            # the changelist, so default to only the latest campaign instead of
+            # showing every campaign's records.
             latest = Campaign.objects.order_by("-ordering_opens").first()
             return queryset.filter(campaign=latest) if latest else queryset
         return queryset.filter(campaign__pk=value)
 
     def choices(self, changelist):
+        # Mirrors Django's default SimpleListFilter.choices(), but with two
+        # deliberate differences from the stock FK filter:
+        #   1. "All" links to `campaign__id__exact=all` (a sentinel value) instead
+        #      of dropping the query param. That's what makes "no param" and
+        #      "explicitly chose All" distinguishable in queryset() above.
+        #   2. The latest campaign's choice is pre-selected when there's no query
+        #      param yet, so the sidebar visually matches what queryset() did.
         latest = Campaign.objects.order_by("-ordering_opens").first()
         yield {
             "selected": self.value() == "all",

--- a/packman/campaigns/admin.py
+++ b/packman/campaigns/admin.py
@@ -51,7 +51,7 @@ class CampaignFilter(admin.SimpleListFilter):
             # No filter param at all means this is the first, unfiltered load of
             # the changelist, so default to only the latest campaign instead of
             # showing every campaign's records.
-            latest = Campaign.objects.order_by("-ordering_opens").first()
+            latest = Campaign.get_latest()
             return queryset.filter(campaign=latest) if latest else queryset
         return queryset.filter(campaign__pk=value)
 
@@ -63,7 +63,7 @@ class CampaignFilter(admin.SimpleListFilter):
         #      "explicitly chose All" distinguishable in queryset() above.
         #   2. The latest campaign's choice is pre-selected when there's no query
         #      param yet, so the sidebar visually matches what queryset() did.
-        latest = Campaign.objects.order_by("-ordering_opens").first()
+        latest = Campaign.get_latest()
         yield {
             "selected": self.value() == "all",
             "query_string": changelist.get_query_string({self.parameter_name: "all"}),

--- a/packman/campaigns/admin.py
+++ b/packman/campaigns/admin.py
@@ -22,18 +22,8 @@ from .models import (
 
 class CampaignFilter(admin.SimpleListFilter):
     """
-    A drop-in replacement for the default "campaign" FK list filter.
-
-    We use a custom filter (instead of just listing "campaign" in
-    ``list_filter``) so that Orders, Prizes, and Products default to showing
-    only the latest campaign when an admin first opens the changelist,
-    rather than dumping every campaign's data on screen at once. The stock
-    FK filter has no concept of a "default" selection: with no query
-    param present it always means "show everything", and its "All" choice
-    works by removing the param entirely - which is indistinguishable from
-    the un-filtered initial state. To get a real default we have to own
-    both `queryset()` (decide what "no param" means) and `choices()`
-    (make "All" its own distinct, stateful choice).
+    A custom "campaign" list filter that defaults to the latest campaign
+    when the changelist is first opened, instead of showing every campaign.
     """
 
     title = _("campaign")

--- a/packman/campaigns/admin.py
+++ b/packman/campaigns/admin.py
@@ -20,6 +20,38 @@ from .models import (
 )
 
 
+class CampaignFilter(admin.SimpleListFilter):
+    title = _("campaign")
+    parameter_name = "campaign__id__exact"
+
+    def lookups(self, request, model_admin):
+        return [(campaign.pk, str(campaign)) for campaign in Campaign.objects.all()]
+
+    def queryset(self, request, queryset):
+        value = self.value()
+        if value == "all":
+            return queryset
+        if value in (None, ""):
+            latest = Campaign.objects.order_by("-ordering_opens").first()
+            return queryset.filter(campaign=latest) if latest else queryset
+        return queryset.filter(campaign__pk=value)
+
+    def choices(self, changelist):
+        latest = Campaign.objects.order_by("-ordering_opens").first()
+        yield {
+            "selected": self.value() == "all",
+            "query_string": changelist.get_query_string({self.parameter_name: "all"}),
+            "display": _("All"),
+        }
+        for lookup, title in self.lookup_choices:
+            yield {
+                "selected": (self.value() is None and latest is not None and str(lookup) == str(latest.pk))
+                or self.value() == str(lookup),
+                "query_string": changelist.get_query_string({self.parameter_name: lookup}),
+                "display": title,
+            }
+
+
 class IsDeliveredFilter(admin.SimpleListFilter):
     title = _("delivered")
     parameter_name = "delivered"
@@ -168,7 +200,7 @@ class OrderAdmin(admin.ModelAdmin):
         "donation",
         "order_total",
     ]
-    list_filter = [IsPaidFilter, IsDeliveredFilter, "campaign", "seller"]
+    list_filter = [IsPaidFilter, IsDeliveredFilter, CampaignFilter, "seller"]
 
     def get_queryset(self, request):
         return super().get_queryset(request).calculate_total()
@@ -186,7 +218,7 @@ class OrderAdmin(admin.ModelAdmin):
 class PrizeAdmin(admin.ModelAdmin):
     actions = ["duplicate_prizes"]
     list_display = ["name", "points", "value", "campaign"]
-    list_filter = ["points", "campaign"]
+    list_filter = ["points", CampaignFilter]
 
     @admin.display(description=_("Copy selected prizes to the latest campaign"))
     def duplicate_prizes(self, request, queryset):
@@ -221,7 +253,7 @@ class ProductAdmin(admin.ModelAdmin):
     actions = ["duplicate_products"]
     filter_horizontal = ["tags"]
     list_display = ["name", "category", "price", "has_description", "has_image", "campaign"]
-    list_filter = ["category", "tags", "campaign"]
+    list_filter = ["category", "tags", CampaignFilter]
 
     def get_readonly_fields(self, request, obj=None):
         # Disallow changing the campaign of a product with orders.

--- a/tests/campaigns/test_admin.py
+++ b/tests/campaigns/test_admin.py
@@ -1,0 +1,97 @@
+from http import HTTPStatus
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from django.urls import reverse
+from django.utils import timezone
+
+from packman.calendars.factories import PackYearFactory
+from packman.campaigns.models import Campaign, Category, Order, Prize, Product
+from packman.membership.factories import ScoutFactory
+
+User = get_user_model()
+
+
+class CampaignFilterTestCase(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.previous_year = PackYearFactory(year=2025)
+        cls.current_year = PackYearFactory(year=2026)
+        cls.previous_campaign = cls.create_campaign(cls.previous_year, timezone.datetime(2025, 9, 1).date())
+        cls.current_campaign = cls.create_campaign(cls.current_year, timezone.datetime(2026, 9, 1).date())
+
+        cls.previous_order = Order.objects.create(campaign=cls.previous_campaign, seller=ScoutFactory())
+        cls.current_order = Order.objects.create(campaign=cls.current_campaign, seller=ScoutFactory())
+
+        cls.previous_prize = Prize.objects.create(name="Old prize", points=1, campaign=cls.previous_campaign)
+        cls.current_prize = Prize.objects.create(name="New prize", points=1, campaign=cls.current_campaign)
+
+        cls.category = Category.objects.create(name="Snacks")
+
+        cls.previous_product = Product.objects.create(
+            name="Old product", price=1, campaign=cls.previous_campaign, category=cls.category
+        )
+        cls.current_product = Product.objects.create(
+            name="New product", price=1, campaign=cls.current_campaign, category=cls.category
+        )
+
+        cls.superuser = User.objects.create_superuser(email="admin@example.com", password="changeme123")  # nosec B106
+
+    @staticmethod
+    def create_campaign(year, ordering_opens):
+        return Campaign.objects.create(
+            year=year,
+            ordering_opens=ordering_opens,
+            ordering_closes=ordering_opens + timezone.timedelta(days=30),
+            delivery_available=ordering_opens + timezone.timedelta(days=45),
+            prize_window_opens=ordering_opens + timezone.timedelta(days=45),
+            prize_window_closes=ordering_opens + timezone.timedelta(days=60),
+        )
+
+    def setUp(self):
+        self.client.force_login(self.superuser)
+
+    def test_order_changelist_defaults_to_latest_campaign(self):
+        url = reverse("admin:campaigns_order_changelist")
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        object_list = list(response.context["cl"].queryset)
+        self.assertIn(self.current_order, object_list)
+        self.assertNotIn(self.previous_order, object_list)
+
+    def test_order_changelist_all_shows_every_campaign(self):
+        url = reverse("admin:campaigns_order_changelist")
+        response = self.client.get(url, {"campaign__id__exact": "all"})
+
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        object_list = list(response.context["cl"].queryset)
+        self.assertIn(self.current_order, object_list)
+        self.assertIn(self.previous_order, object_list)
+
+    def test_order_changelist_specific_campaign(self):
+        url = reverse("admin:campaigns_order_changelist")
+        response = self.client.get(url, {"campaign__id__exact": self.previous_campaign.pk})
+
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        object_list = list(response.context["cl"].queryset)
+        self.assertIn(self.previous_order, object_list)
+        self.assertNotIn(self.current_order, object_list)
+
+    def test_prize_changelist_defaults_to_latest_campaign(self):
+        url = reverse("admin:campaigns_prize_changelist")
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        object_list = list(response.context["cl"].queryset)
+        self.assertIn(self.current_prize, object_list)
+        self.assertNotIn(self.previous_prize, object_list)
+
+    def test_product_changelist_defaults_to_latest_campaign(self):
+        url = reverse("admin:campaigns_product_changelist")
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        object_list = list(response.context["cl"].queryset)
+        self.assertIn(self.current_product, object_list)
+        self.assertNotIn(self.previous_product, object_list)


### PR DESCRIPTION
## What
Orders, Prizes, and Products in the admin now default to showing only the latest campaign's records when the changelist is first opened, instead of listing every campaign at once.

## How
Added a `CampaignFilter(admin.SimpleListFilter)` in `packman/campaigns/admin.py`, used in place of the plain `"campaign"` FK filter on `OrderAdmin`, `PrizeAdmin`, and `ProductAdmin`:

- No `campaign__id__exact` query param (first load) → filters to `Campaign.get_latest()`.
- `campaign__id__exact=all` → shows every campaign (this is what the sidebar's "All" choice now links to, instead of dropping the param, so it can't be confused with "no filter selected yet").
- A specific campaign pk → filters to that campaign, as before.

## Tests
Added `tests/campaigns/test_admin.py` covering:
- Orders/Prizes/Products changelists default to the latest campaign.
- Selecting "All" shows every campaign.
- Selecting a specific campaign still filters correctly.

## Verification
- `python manage.py check` — clean
- Full test suite: 132/132 passing
- `ruff check` — no new issues introduced (21 pre-existing issues in the file, unchanged before/after)

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>

## Summary by Sourcery

Make campaign-based admin lists open focused on the latest campaign while retaining clear options to view all or a selected campaign.

Enhancements:
- Default Orders, Prizes, and Products admin changelists to the latest campaign while preserving explicit all-campaign and single-campaign filtering.

Tests:
- Add admin changelist coverage for latest-campaign defaults, all-campaign selection, and specific campaign filtering.